### PR TITLE
NPCs/Quests/Spells-fixed/added.

### DIFF
--- a/data/XML/quests.xml
+++ b/data/XML/quests.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <quests>
 	<quest name="The Explorer Society" startstorageid="90" startstoragevalue="1">
-     <mission name="Joining the Explorers" storageid="90" startvalue="1" endvalue="4">
+     <mission name="Joining the Explorers" storageid="118" startvalue="1" endvalue="4">
          <missionstate id="1" description="The mission should be simple to fulfil. You have to seek out Uzgod in Kazordoon and get the pickaxe for us. Or just find dwarven pickaxe on your own..."/>
          <missionstate id="2" description="Get into Dwacatra and bring family brooch back to Uzgod."/>
          <missionstate id="3" description="Bring the pickaxe back to the Explorer Society representative."/>
+         <missionstate id="4" description="You brought the pickaxe back to the Explorer Society representative."/>
      </mission>
-     <mission name="The Ice Delivery" storageid="90" startvalue="5" endvalue="7">
+     <mission name="The Ice Delivery" storageid="102" startvalue="5" endvalue="7">
          <missionstate id="5" description="Take this ice pick and use it on a block of ice in the caves beneath Folda. Get some ice and bring it here as fast as you can. If the ice melt away, report on your ice delivery mission anyway."/>
          <missionstate id="6" description="You have 10 minutes before the icicle defrosts. Run back to the Explorer Society representative!"/>
+		 <missionstate id="7" description="You have delivered the ice."/>
      </mission>	 	 
-     <mission name="The Butterfly Hunt" storageid="90" startvalue="8" endvalue="16">
+     <mission name="The Butterfly Hunt" storageid="103" startvalue="8" endvalue="16">
          <missionstate id="8" description="This preparation kit will allow you to collect a PURPLE butterfly you have killed. Just use it on the fresh corpse of a PURPLE butterfly."/>
          <missionstate id="9" description="Return the prepared butterfly to Explorer Society representative."/>
          <missionstate id="10" description="Ask for another butterfly hunt."/>
@@ -19,8 +21,9 @@
          <missionstate id="13" description="Ask for another butterfly hunt."/>
          <missionstate id="14" description="This preparation kit will allow you to collect a RED butterfly you have killed. Just use it on the fresh corpse of a RED butterfly."/>
          <missionstate id="15" description="Return the prepared butterfly to Explorer Society representative."/>
+         <missionstate id="16" description="You completed the Butterfly Hunt."/>
      </mission>
-     <mission name="The Plant Collection" storageid="90" startvalue="17" endvalue="26">
+     <mission name="The Plant Collection" storageid="104" startvalue="17" endvalue="26">
          <missionstate id="17" description="Take botanist's container. Use it on a jungle bells plant to collect a sample."/>
          <missionstate id="18" description="Report about your plant collection to Explorer Society representative."/>
          <missionstate id="19" description="Ask for plant collection when you are ready to continue."/>
@@ -29,53 +32,64 @@
          <missionstate id="22" description="Ask for plant collection when you are ready to continue."/>
          <missionstate id="23" description="Use this botanist's container on a giant jungle rose to obtain a sample."/>
          <missionstate id="24" description="Report about your plant collection to Explorer Society representative."/>
+         <missionstate id="26" description="You completed the Plant Collection."/>
      </mission>
-     <mission name="The Lizard Urn" storageid="90" startvalue="27" endvalue="29">
+     <mission name="The Lizard Urn" storageid="105" startvalue="27" endvalue="29">
          <missionstate id="27" description="In the south-east of Tiquanda is a small settlement of the lizard people. Beneath the newly constructed temple there, the lizards hide the urn. Acquire an ancient urn which is some sort of relic to the lizard people of Tiquanda."/>
          <missionstate id="28" description="Bring the Funeral Urn back to the Explorer Society."/>
+         <missionstate id="29" description="You brought the Funeral Urn back to the Explorer Society."/>		 
      </mission>
-     <mission name="The Bonelord Secret" storageid="90" startvalue="30" endvalue="32">
+     <mission name="The Bonelord Secret" storageid="106" startvalue="30" endvalue="32">
          <missionstate id="30" description="Travel to the city of Darashia and then head north-east for the pyramid. If any documents are left, you probably find them in the catacombs beneath."/>
          <missionstate id="31" description="Bring the Wrinkled Parchment back to the Explorer Society representative."/>
+         <missionstate id="32" description="You brought the Wrinkled Parchment back to the Explorer Society representative."/>
      </mission>
-     <mission name="The Orc Powder" storageid="90" startvalue="33" endvalue="35">
+     <mission name="The Orc Powder" storageid="107" startvalue="33" endvalue="35">
          <missionstate id="33" description="As far as we can tell, the orcs maintain some sort of training facility in some hill in the north-east of their city. There you should find lots of their war wolves and hopefully also some of the orcish powder."/>
          <missionstate id="34" description="Bring the Strange Powder to the Explorer Society representative to complete your mission."/>
+		 <missionstate id="35" description="You brought the Strange Powder to the Explorer Society representative to complete your mission."/>
      </mission>
-     <mission name="The Elven Poetry" storageid="90" startvalue="36" endvalue="38">
+     <mission name="The Elven Poetry" storageid="108" startvalue="36" endvalue="38">
          <missionstate id="36" description="This mission is easy but nonetheless vital. Travel Hellgate beneath Ab'Dendriel and get the book."/>
          <missionstate id="37" description="Bring back an elven poetry book to the Explorer Society representative."/>
+         <missionstate id="38" description="You brought back an elven poetry book to the Explorer Society representative."/>
      </mission>
-     <mission name="The Memory Stone" storageid="90" startvalue="39" endvalue="41">
+     <mission name="The Memory Stone" storageid="109" startvalue="39" endvalue="41">
          <missionstate id="39" description="In the ruins of north-western Edron you should be able to find a memory stone."/>
          <missionstate id="40" description="Bring back a memory stone to the Explorer Society representative."/>
+         <missionstate id="41" description="You brought back a memory stone to the Explorer Society representative."/>
      </mission>
-     <mission name="The Rune Writings" storageid="90" startvalue="42" endvalue="47">
+     <mission name="The Rune Writings" storageid="117" startvalue="42" endvalue="44">
          <missionstate id="42" description="Somewhere under the ape infested city of Banuta, one can find dungeons that were once inhabited by lizards. Look there for an atypical structure that would rather fit to Ankrahmun and its Ankrahmun Tombs. Copy the runes you will find on this"/>
          <missionstate id="43" description="Report back to the Explorer Society representative."/>
+		 <missionstate id="44" description="You reported back to the Explorer Society representative."/>
      </mission>
-     <mission name="The Ectoplasm" storageid="90" startvalue="45" endvalue="47">
+     <mission name="The Ectoplasm" storageid="111" startvalue="45" endvalue="47">
          <missionstate id="45" description="Take ectoplasm container and use it on a ghost that was recently slain."/>
          <missionstate id="46" description="Return back to the Explorer Society representative with the collected ectoplasm."/>
+         <missionstate id="47" description="Returned back to the Explorer Society representative with the collected ectoplasm."/>
      </mission>
-     <mission name="The Spectral Dress" storageid="90" startvalue="48" endvalue="50">
+     <mission name="The Spectral Dress" storageid="112" startvalue="48" endvalue="50">
          <missionstate id="48" description="The queen of the banshees lives in the so called Ghostlands, south west of Carlin. Try to get a spectral dress from her."/>
          <missionstate id="49" description="Report to the Explorer Society with the spectral dress."/>
+         <missionstate id="50" description="Reported to the Explorer Society with the spectral dress."/>
      </mission>
-     <mission name="The Spectral Stone" storageid="90" startvalue="51" endvalue="55">
+     <mission name="The Spectral Stone" storageid="113" startvalue="51" endvalue="55">
          <missionstate id="51" description="Please travel to our second base and ask them to mail us their latest research reports. Then return here and ask about new missions."/>
          <missionstate id="52" description="Tell our fellow explorer that the papers are in the mail already."/>
          <missionstate id="53" description="Take the spectral essence and use it on the strange carving in this building as well as on the corresponding tile in our second base."/>
          <missionstate id="54" description="Good! Now use the spectral essence on the strange carving in our second base."/>
+         <missionstate id="55" description="Used the spectral essence on the strange carving in both bases."/>
      </mission>
-     <mission name="The Astral Portals" storageid="90" startvalue="56" endvalue="56">
+     <mission name="The Astral Portals" storageid="114" startvalue="56" endvalue="56">
          <missionstate id="56" description="Both carvings are now charged and harmonised. You are able to travel in zero time from one base to the other, but you need to have an orichalcum pearl in your possession to use it as power source."/>
      </mission>
-     <mission name="The Island of Dragons" storageid="90" startvalue="57" endvalue="58">
+     <mission name="The Island of Dragons" storageid="115" startvalue="57" endvalue="59">
          <missionstate id="57" description="Travel to Okolnir and try to find a proof for the existence of dragon lords there in the old times. I think old Buddel might be able to bring you there."/>
          <missionstate id="58" description="Report back to Lurik with the dragon scale."/>
+		 <missionstate id="59" description="Reported back to Lurik with the dragon scale."/>
      </mission>
-     <mission name="The Ice Music" storageid="90" startvalue="60" endvalue="62">
+     <mission name="The Ice Music" storageid="116" startvalue="60" endvalue="62">
          <missionstate id="60" description="There is a cave on Hrodmir, north of the southernmost barbarian camp Krimhorn. In this cave, there are a waterfall and a lot of stalagmites. Take the resonance crystal and use it on the stalagmites in the cave to record the sound of the wind"/>
          <missionstate id="61" description="Report back to Lurik."/>
          <missionstate id="62" description="Now you may use the Astral Bridge from Liberty Bay to Svargrond."/>
@@ -83,7 +97,7 @@
      <mission name="The Undersea Kingdom" storageid="93" startvalue="1" endvalue="3">
          <missionstate id="1" description="Captain Max will bring you to Calassa whenever you are ready. Please try to retrieve the missing logbook which must be in one of the sunken shipwrecks."/>
          <missionstate id="2" description="Report about your Calassa mission to Berenice in Liberty Bay."/>
-		 <missionstate id="3" description="You complete the task."/>
+		 <missionstate id="3" description="You completed the task."/>
      </mission>
 </quest>
 

--- a/data/lib/core/quests.lua
+++ b/data/lib/core/quests.lua
@@ -4,11 +4,12 @@ if not Quests then
 			name = "The Explorer Society", startstorageid = Storage.ExplorerSociety.QuestLine, startstoragevalue = 1,
 			missions = {
 				[1] = {
-					name = "Joining the Explorers", storageid = Storage.ExplorerSociety.QuestLine, startvalue = 1, endvalue = 4,
+					name = "Joining the Explorers", storageid = Storage.ExplorerSociety.JoiningtheExplorers, startvalue = 1, endvalue = 4,
 					states = {
 						[1] = "The mission should be simple to fulfil. You have to seek out Uzgod in Kazordoon and get the pickaxe for us. Or just find dwarven pickaxe on your own...",
 						[2] = "Get into Dwacatra and bring family brooch back to Uzgod.",
 						[3] = "Bring the pickaxe back to the Explorer Society representative.",
+						[4] = "You brought the pickaxe back to the Explorer Society representative.",
 					},
 
 				},
@@ -62,7 +63,7 @@ if not Quests then
 				},
 
 				[6] = {
-					name = "The Bonelord Secret", storageid = Storage.ExplorerSociety.QuestLine, startvalue = 30, endvalue = 32,
+					name = "The Beholder Secret", storageid = Storage.ExplorerSociety.QuestLine, startvalue = 30, endvalue = 32,
 					states = {
 						[30] = "Travel to the city of Darashia and then head north-east for the pyramid. If any documents are left, you probably find them in the catacombs beneath.",
 						[31] = "Bring the Wrinkled Parchment back to the Explorer Society representative.",
@@ -98,7 +99,7 @@ if not Quests then
 				},
 
 				[10] = {
-					name = "The Rune Writings", storageid = Storage.ExplorerSociety.QuestLine, startvalue = 42, endvalue = 47,
+					name = "The Rune Writings", storageid = Storage.ExplorerSociety.QuestLine, startvalue = 42, endvalue = 44,
 					states = {
 						[42] = "Somewhere under the ape infested city of Banuta, one can find dungeons that were once inhabited by lizards. Look there for an atypical structure that would rather fit to Ankrahmun and its Ankrahmun Tombs. Copy the runes you will find on this structure.",
 						[43] = "Report back to the Explorer Society representative.",

--- a/data/npc/scripts/Angus.lua
+++ b/data/npc/scripts/Angus.lua
@@ -40,13 +40,13 @@ local function creatureSayCallback(cid, type, msg)
         -- MISSION CHECK
     elseif msgcontains(msg, "mission") then
         if player:getStorageValue(Storage.ExplorerSociety.JoiningtheExplorers) > 3 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) > 3 and player:getStorageValue(Storage.ExplorerSociety.ThePlantCollection) < 26 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) < 26 or player:getStorageValue(Storage.ExplorerSociety.TheIceDelivery) == 7 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 7 or player:getStorageValue(Storage.ExplorerSociety.TheButterflyHunt) == 16 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 16 or player:getStorageValue(Storage.ExplorerSociety.JoiningtheExplorers) == 4 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 4 then
-            npcHandler:say("The missions available for your rank are the {butterfly hunt}, {plant collection} and {ice delivery}.", cid)
+            npcHandler:say("The missions available for your rank are the {Butterfly hunt}, {Plant collection} and {Ice delivery}.", cid)
             npcHandler.topic[cid] = 0
         elseif player:getStorageValue(Storage.ExplorerSociety.ThePlantCollection) > 25 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) > 35 and player:getStorageValue(Storage.ExplorerSociety.TheOrcPowder) < 35 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) < 35 or player:getStorageValue(Storage.ExplorerSociety.ThePlantCollection) == 26 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 26 or player:getStorageValue(Storage.ExplorerSociety.TheLizardUrn) == 29  and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 29 or player:getStorageValue(Storage.ExplorerSociety.TheBonelordSecret) == 32 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 32 then
-            npcHandler:say("The missions available for your rank are {lizard urn}, {bonelord secrets} and {orc powder}.", cid)
+            npcHandler:say("The missions available for your rank are {Lizard Urn}, {Beholder secrets} and {Orc Powder}.", cid)
             npcHandler.topic[cid] = 0
         elseif player:getStorageValue(Storage.ExplorerSociety.TheOrcPowder) > 34 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) > 34 and player:getStorageValue(Storage.ExplorerSociety.TheRuneWritings) < 44 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) < 44 or player:getStorageValue(Storage.ExplorerSociety.TheOrcPowder) == 35 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 35 or player:getStorageValue(Storage.ExplorerSociety.TheElvenPoetry) == 38 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 38 or player:getStorageValue(Storage.ExplorerSociety.TheMemoryStone) == 41 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 41 then
-            npcHandler:say("The missions available for your rank are {elven poetry}, {memory stone} and {rune writings}.", cid)
+            npcHandler:say("The missions available for your rank are {Elven Poetry}, {Memory Stone} and {Rune Writings}.", cid)
             npcHandler.topic[cid] = 0
         elseif player:getStorageValue(Storage.ExplorerSociety.TheRuneWritings) == 44 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 44 then
             npcHandler:say("The explorer society needs a great deal of help in the research of astral travel. Are you willing to help?", cid)
@@ -106,7 +106,7 @@ local function creatureSayCallback(cid, type, msg)
         -- PICKAXE MISSION
 
         -- ICE DELIVERY
-    elseif msgcontains(msg, "ice delivery") then
+    elseif msgcontains(msg, "ice") or msgcontains(msg, "delivery") then
         if player:getStorageValue(Storage.ExplorerSociety.JoiningtheExplorers) == 4 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 4 then
             npcHandler:say({
                 "Our finest minds came up with the theory that deep beneath the ice island of Folda ice can be found that is ancient. To prove this theory we would need a sample of the aforesaid ice ...",
@@ -121,7 +121,7 @@ local function creatureSayCallback(cid, type, msg)
         -- ICE DELIVERY
 
         -- BUTTERFLY HUNT
-    elseif msgcontains(msg, "butterfly hunt") then
+    elseif msgcontains(msg, "butterfly") or msgcontains(msg, "hunt") then
         if player:getStorageValue(Storage.ExplorerSociety.TheIceDelivery) == 7 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 7 then
             npcHandler:say("The mission asks you to collect some species of butterflies, are you interested?", cid)
             npcHandler.topic[cid] = 7
@@ -155,7 +155,7 @@ local function creatureSayCallback(cid, type, msg)
         end
         -- BUTTERFLY HUNT
         -- PLANT COLLECTION
-    elseif msgcontains(msg, "plant collection") then
+    elseif msgcontains(msg, "plant") or msgcontains(msg, "collection") then
         if player:getStorageValue(Storage.ExplorerSociety.TheButterflyHunt) == 16 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 16 then
             npcHandler:say("In this mission we require you to get us some plant samples from Tiquandan plants. Would you like to fulfil this mission?", cid)
             npcHandler.topic[cid] = 11
@@ -184,7 +184,7 @@ local function creatureSayCallback(cid, type, msg)
         -- PLANT COLLECTION
 
         -- LIZARD URN
-    elseif msgcontains(msg, "lizard urn") then
+    elseif msgcontains(msg, "urn") then
         if player:getStorageValue(Storage.ExplorerSociety.ThePlantCollection) == 26 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 26 then
             npcHandler:say("The explorer society would like to acquire an ancient urn which is some sort of relic to the lizard people of Tiquanda. Would you like to accept this mission?", cid)
             npcHandler.topic[cid] = 15
@@ -195,22 +195,22 @@ local function creatureSayCallback(cid, type, msg)
         -- LIZARD URN
 
         -- BONELORDS
-    elseif msgcontains(msg, "bonelord secrets") then
+    elseif msgcontains(msg, "beholder") or msgcontains(msg, "secrets") then
         if player:getStorageValue(Storage.ExplorerSociety.TheLizardUrn) == 29  and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 29 then
             npcHandler:say({
-                "We want to learn more about the ancient race of bonelords. We believe the black pyramid north east of Darashia was originally built by them ...",
-                "We ask you to explore the ruins of the black pyramid and look for any signs that prove our theory. You might probably find some document with the numeric bonelord language ...",
+                "We want to learn more about the ancient race of beholders. We believe the black pyramid north east of Darashia was originally built by them ...",
+                "We ask you to explore the ruins of the black pyramid and look for any signs that prove our theory. You might probably find some document with the numeric beholder language ...",
                 "That would be sufficient proof. Would you like to accept this mission?"
             }, cid)
             npcHandler.topic[cid] = 17
         elseif player:getStorageValue(Storage.ExplorerSociety.TheBonelordSecret) == 31 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 30 then
-            npcHandler:say("Have you found any proof that the pyramid was built by bonelords?", cid)
+            npcHandler:say("Have you found any proof that the pyramid was built by beholders?", cid)
             npcHandler.topic[cid] = 18
         end
-        -- BONELORDS
+        -- BEHOLDERS
 
         -- ORC POWDER
-    elseif msgcontains(msg, "orc powder") then
+    elseif msgcontains(msg, "orc") or msgcontains(msg, "powder") then
         if player:getStorageValue(Storage.ExplorerSociety.TheBonelordSecret) == 32 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 32 then
             npcHandler:say({
                 "It is commonly known that orcs of Uldereks Rock use some sort of powder to increase the fierceness of their war wolves and berserkers ...",
@@ -225,7 +225,7 @@ local function creatureSayCallback(cid, type, msg)
         -- ORC POWDER
 
         -- ELVEN POETRY
-    elseif msgcontains(msg, "elven poetry") then
+    elseif msgcontains(msg, "elven") or msgcontains(msg, "poetry") then
         if player:getStorageValue(Storage.ExplorerSociety.TheOrcPowder) == 35 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 35 then
             npcHandler:say({
                 "Some high ranking members would like to study elven poetry. They want the rare book 'Songs of the Forest' ...",
@@ -239,7 +239,7 @@ local function creatureSayCallback(cid, type, msg)
         -- ELVEN POETRY
 
         -- MEMORY STONE
-    elseif msgcontains(msg, "memory stone") then
+    elseif msgcontains(msg, "memory") then
         if player:getStorageValue(Storage.ExplorerSociety.TheElvenPoetry) == 38 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 38 then
             npcHandler:say({
                 "We acquired some knowledge about special magic stones. Some lost civilisations used it to store knowledge and lore, just like we use books ...",
@@ -254,7 +254,7 @@ local function creatureSayCallback(cid, type, msg)
         -- MEMORY STONE
 
         -- RUNE WRITINGS
-    elseif msgcontains(msg, "rune writings") then
+    elseif msgcontains(msg, "rune") or msgcontains(msg, "writings") then
         if player:getStorageValue(Storage.ExplorerSociety.TheMemoryStone) == 41 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 41 then
             npcHandler:say({
                 "We would like to study some ancient runes that were used by the lizard race. We suspect some relation of the lizards to the founders of Ankrahmun ...",
@@ -398,7 +398,7 @@ local function creatureSayCallback(cid, type, msg)
             end
             -- LIZARD URN
 
-            -- BONELORDS
+            -- BEHOLDERS
         elseif npcHandler.topic[cid] == 17 then
             player:setStorageValue(Storage.ExplorerSociety.TheBonelordSecret, 30)
 			player:setStorageValue(Storage.ExplorerSociety.QuestLine, 30)
@@ -415,7 +415,7 @@ local function creatureSayCallback(cid, type, msg)
                 npcHandler:say("You did it! Excellent! The scientific world will be shaken by this discovery!", cid)
                 npcHandler.topic[cid] = 0
             end
-            -- BONELORDS
+            -- BEHOLDERS
 
             -- ORC POWDER
         elseif npcHandler.topic[cid] == 19 then
@@ -579,19 +579,23 @@ local function creatureSayCallback(cid, type, msg)
         -- ANSWER NO
 
         -- SKULL OF RATHA / GIANT SMITHHAMMER
-    elseif msgcontains(msg, "skull of ratha") and player:getStorageValue(Storage.ExplorerSociety.skullofratha) < 1 then
+    elseif msgcontains(msg, "skull") or msgcontains(msg, "ratha") and player:getStorageValue(Storage.ExplorerSociety.skullofratha) < 1 then
         npcHandler:say({
             "Ratha was a great explorer and even greater ladies' man. Sadly he never returned from a visit to the amazons. Probably he is dead ...",
             "The society offers a substantial reward for the retrieval of Ratha or his remains. Do you have any news about Ratha?"
         }, cid)
         npcHandler.topic[cid] = 33
-    elseif msgcontains(msg, "giant smith hammer") and player:getStorageValue(Storage.ExplorerSociety.giantsmithhammer) < 1 then
+    elseif msgcontains(msg, "giant") and player:getStorageValue(Storage.ExplorerSociety.giantsmithhammer) < 1 then
         npcHandler:say("The explorer society is looking for a genuine giant smith hammer for our collection. It is rumoured the cyclopses of the Plains of Havoc might be using one. Did you by chance obtain such a hammer?", cid)
         npcHandler.topic[cid] = 34
         -- SKULL OF RATHA / GIANT SMITHHAMMER
     end
     return true
 end
+
+npcHandler:setMessage(MESSAGE_GREET, "Be greeted, noble |PLAYERNAME| and welcome to the Explorer Society.")
+npcHandler:setMessage(MESSAGE_FAREWELL, "Come back soon, noble |PLAYERNAME|.")
+npcHandler:setMessage(MESSAGE_WALKAWAY, "Come back soon, noble.")
 
 npcHandler:setCallback(CALLBACK_MESSAGE_DEFAULT, creatureSayCallback)
 npcHandler:addModule(FocusModule:new())

--- a/data/npc/scripts/Berenice.lua
+++ b/data/npc/scripts/Berenice.lua
@@ -26,10 +26,12 @@ local function creatureSayCallback(cid, type, msg)
 		elseif npcHandler.topic[cid] == 4 then
 			npcHandler:say("Captain Max will bring you to Calassa whenever you are ready. Please try to retrieve the missing logbook which must be in one of the sunken shipwrecks.", cid)
 			player:setStorageValue(Storage.ExplorerSociety.QuestLine, 63)
+			player:setStorageValue(Storage.ExplorerSociety.CalassaQuest, 1)
 			player:setStorageValue(Storage.ExplorerSociety.calassaDoor, 1)
 			npcHandler.topic[cid] = 0
-		elseif player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 64 then
+		elseif player:getStorageValue(Storage.ExplorerSociety.CalassaQuest) == 2 then
 			npcHandler:say("OH! So you have safely returned from Calassa! Congratulations, were you able to retrieve the logbook?", cid)
+			player:setStorageValue(Storage.ExplorerSociety.QuestLine, 64)
 			npcHandler.topic[cid] = 5
 		end
 	elseif msgcontains(msg, "yes") then
@@ -52,6 +54,7 @@ local function creatureSayCallback(cid, type, msg)
 			if player:removeItem(6124, 1) then
 				player:setStorageValue(Storage.ExplorerSociety.QuestLine, 65)
 				npcHandler:say("Yes! That's the logbook! However... it seems that the water has already destroyed many of the pages. This is not your fault though, you did your best. Thank you!", cid)
+				player:setStorageValue(Storage.ExplorerSociety.CalassaQuest, 3)
 				npcHandler.topic[cid] = 0
 			end
 		end

--- a/data/npc/scripts/Elvith.lua
+++ b/data/npc/scripts/Elvith.lua
@@ -7,11 +7,55 @@ function onCreatureDisappear(cid)		npcHandler:onCreatureDisappear(cid)			end
 function onCreatureSay(cid, type, msg)		npcHandler:onCreatureSay(cid, type, msg)		end
 function onThink()				npcHandler:onThink()					end
 
+
+local function creatureSayCallback(cid, type, msg)
+	if not npcHandler:isFocused(cid) then
+		return false
+	end 
+    local player = Player(cid)
+
+
+	if msgcontains(msg, 'songs of the forest') then
+		npcHandler:say({
+			'The last issue I had was bought by Randor Swiftfinger. He was banished through the hellgate and probably took the book with him ...',
+			'I would not recommend seeking him or the book there, but of course it is possible.'
+		}, cid)
+	elseif msgcontains(msg, 'love poem') then
+		npcHandler:say('Do you want to buy a poem scroll for 200 gold?', cid)
+		npcHandler.topic[cid] = 1
+	elseif msgcontains(msg, 'poetry book') and player:getStorageValue(Storage.ExplorerSociety.TheElvenPoetry) == 37 then
+		npcHandler:say('Do you want to buy the Elven Poetry Book for 500 gold?', cid)
+		npcHandler.topic[cid] = 2
+	elseif msgcontains(msg, 'song') then
+		npcHandler:say('Everything is a song. Life, death, history ... everything. To listen to the song of something is the first step to understand it.', cid)
+	elseif msgcontains(msg, 'yes') then
+		if npcHandler.topic[cid] == 1 then
+			npcHandler.topic[cid] = 0
+			if not player:removeMoney(200) then
+				npcHandler:say('You don\'t have enough money.', cid)
+				return true
+			end
+
+			player:addItem(5952, 1)
+			npcHandler:say('Here it is.', cid)
+		elseif npcHandler.topic[cid] == 2 then
+			npcHandler.topic[cid] = 0
+			if not player:removeMoney(500) then
+				npcHandler:say('You don\'t have enough money.', cid)
+				return true
+			end
+			
+			player:addItem(4855, 1)
+			npcHandler:say('Here it is.', cid)
+		end
+	end
+	return true
+end
+
 keywordHandler:addKeyword({'job'}, StdModule.say, {npcHandler = npcHandler, text = 'I sell musical instruments of many kinds.'})
 keywordHandler:addKeyword({'instruments'}, StdModule.say, {npcHandler = npcHandler, text = 'I sell lyres, lutes, drums, and simple fanfares.'})
 keywordHandler:addKeyword({'music'}, StdModule.say, {npcHandler = npcHandler, text = 'Music is an attempt to condensate emotions in harmonies and save them for the times to come.'})
 keywordHandler:addKeyword({'time'}, StdModule.say, {npcHandler = npcHandler, text = 'Time has its own song. Close your eyes and listen to the symphony of the seasons.'})
-keywordHandler:addKeyword({'song'}, StdModule.say, {npcHandler = npcHandler, text = 'Everything is a song. Life, death, history ... everything. To listen to the song of something is the first step to understand it.'})
 keywordHandler:addKeyword({'melody'}, StdModule.say, {npcHandler = npcHandler, text = 'Everything is a song. Life, death, history ... everything. To listen to the song of something is the first step to understand it.'})
 keywordHandler:addKeyword({'elf'}, StdModule.say, {npcHandler = npcHandler, text = 'We are the most graceful of all races. We feel the music of the universe in our hearts and souls.'})
 keywordHandler:addKeyword({'kuridai'}, StdModule.say, {npcHandler = npcHandler, text = 'They could dig some halls for a big musical event, but they won\'t listen to me about that matter.'})
@@ -23,35 +67,6 @@ keywordHandler:addKeyword({'cenath'}, StdModule.say, {npcHandler = npcHandler, t
 keywordHandler:addKeyword({'troll'}, StdModule.say, {npcHandler = npcHandler, text = 'I went down to the mines and tried to lighten up their spirit, the foolish creatures did not listen to my songs, though.'})
 keywordHandler:addKeyword({'magic'}, StdModule.say, {npcHandler = npcHandler, text = 'Sorry, I don\'t feel like teaching magic today.'})
 keywordHandler:addKeyword({'hellgate'}, StdModule.say, {npcHandler = npcHandler, text = 'For the worst of crimes, criminals are cast into hellgate. It is said no one can return from there. Since it is not actually forbidden to enter hellgate, you might convince Elathriel to grant you entrance.'})
-
-local function creatureSayCallback(cid, type, msg)
-	if not npcHandler:isFocused(cid) then
-		return false
-	end
-
-	if msgcontains(msg, 'songs of the forest') then
-		npcHandler:say({
-			'The last issue I had was bought by Randor Swiftfinger. He was banished through the hellgate and probably took the book with him ...',
-			'I would not recommend seeking him or the book there, but of course it is possible.'
-		}, cid)
-	elseif msgcontains(msg, 'love poem') then
-		npcHandler:say('Do you want to buy a poem scroll for 200 gold?', cid)
-		npcHandler.topic[cid] = 1
-	elseif msgcontains(msg, 'yes') then
-		if npcHandler.topic[cid] == 1 then
-			npcHandler.topic[cid] = 0
-			local player = Player(cid)
-			if not player:removeMoney(200) then
-				npcHandler:say('You don\'t have enough money.', cid)
-				return true
-			end
-
-			player:addItem(5952, 1)
-			npcHandler:say('Here it is.', cid)
-		end
-	end
-	return true
-end
 
 npcHandler:setCallback(CALLBACK_MESSAGE_DEFAULT, creatureSayCallback)
 npcHandler:setMessage(MESSAGE_GREET, 'Ashari |PLAYERNAME|.')

--- a/data/npc/scripts/Eremo.lua
+++ b/data/npc/scripts/Eremo.lua
@@ -19,20 +19,21 @@ end
 
 
 local node1 = keywordHandler:addKeyword({'challenge'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Challenge for 2000 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'challenge'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'challenge', price = 2000})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'conjure power bolt'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Conjure Power Bolt for 2000 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure power bolt'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure power bolt', price = 2000})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'enchant staff'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Enchant Staff for 2000 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'enchant staff'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'enchant staff', price = 2000})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'wild growth'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Wild Growth for 2000 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'wild growth'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'wild growth', price = 2000})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
 
 
 local shopModule = ShopModule:new()

--- a/data/npc/scripts/Eremo.lua
+++ b/data/npc/scripts/Eremo.lua
@@ -17,6 +17,24 @@ local function greetCallback(cid)
 	return true
 end
 
+
+local node1 = keywordHandler:addKeyword({'challenge'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Challenge for 2000 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'challenge'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'conjure power bolt'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Conjure Power Bolt for 2000 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure power bolt'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'enchant staff'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Enchant Staff for 2000 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'enchant staff'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'wild growth'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Wild Growth for 2000 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'wild growth'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+
 local shopModule = ShopModule:new()
 npcHandler:addModule(shopModule)
 

--- a/data/npc/scripts/Gundralph.lua
+++ b/data/npc/scripts/Gundralph.lua
@@ -8,28 +8,29 @@ function onCreatureSay(cid, type, msg) npcHandler:onCreatureSay(cid, type, msg) 
 function onThink() npcHandler:onThink() end
 
 local node1 = keywordHandler:addKeyword({'cancel invisibility'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Cancel Invisibility for 1600 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'cancel invisibility'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'cancel invisibility', price = 1600})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'enchant spear'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Enchant Spear for 2000 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'enchant spear'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'enchant spear', price = 2000})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'magic wall'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Magic Wall for 2100 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'Magic Wall'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'Magic Wall', price = 2100})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'soulfire'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Soulfire for 1800 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'soulfire'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'soulfire', price = 1800})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'undead legion'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Undead Legion for 2000 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'undead legion'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'undead legion', price = 2000})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'ultimate light'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Ultimate Light for 1600 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'ultimate light'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'ultimate light', price = 1600})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
 
 keywordHandler:addKeyword({'job'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I am a teacher for some powerful Spells."})
 keywordHandler:addKeyword({'name'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "They call me Gundralph."})
@@ -45,6 +46,6 @@ keywordHandler:addKeyword({'edron'}, StdModule.say, {npcHandler = npcHandler, on
 keywordHandler:addKeyword({'new'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I have heard nothing of intrest lately, sorry."})
 keywordHandler:addKeyword({'rumo'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I have heard nothing of intrest lately, sorry."})
 keywordHandler:addKeyword({'spellbook'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "Please ask the stationer in the west tower for that."})
-keywordHandler:addKeyword({'spell'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I have 'Ultimate Light', 'Soul Fire', 'Magic Wall', 'Cancel Invisibility', and 'Undead Legion'. Are you interested?"})
+keywordHandler:addKeyword({'spell'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I have 'Ultimate Light', 'Soulfire', 'Magic Wall', 'Cancel Invisibility', 'Enchant Spear' and 'Undead Legion'. Are you interested?"})
 
 npcHandler:addModule(FocusModule:new())

--- a/data/npc/scripts/Gundralph.lua
+++ b/data/npc/scripts/Gundralph.lua
@@ -7,6 +7,30 @@ function onCreatureDisappear(cid) npcHandler:onCreatureDisappear(cid) end
 function onCreatureSay(cid, type, msg) npcHandler:onCreatureSay(cid, type, msg) end
 function onThink() npcHandler:onThink() end
 
+local node1 = keywordHandler:addKeyword({'cancel invisibility'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Cancel Invisibility for 1600 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'cancel invisibility'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'enchant spear'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Enchant Spear for 2000 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'enchant spear'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'magic wall'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Magic Wall for 2100 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'Magic Wall'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'soulfire'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Soulfire for 1800 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'soulfire'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'undead legion'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Undead Legion for 2000 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'undead legion'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'ultimate light'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Ultimate Light for 1600 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'ultimate light'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
 keywordHandler:addKeyword({'job'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I am a teacher for some powerful Spells."})
 keywordHandler:addKeyword({'name'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "They call me Gundralph."})
 keywordHandler:addKeyword({'king'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "Unfortunately, I never met King Tibianus III in person."})

--- a/data/npc/scripts/Mortimer.lua
+++ b/data/npc/scripts/Mortimer.lua
@@ -40,13 +40,13 @@ local function creatureSayCallback(cid, type, msg)
         -- MISSION CHECK
     elseif msgcontains(msg, "mission") then
         if player:getStorageValue(Storage.ExplorerSociety.JoiningtheExplorers) > 3 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) > 3 and player:getStorageValue(Storage.ExplorerSociety.ThePlantCollection) < 26 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) < 26 or player:getStorageValue(Storage.ExplorerSociety.TheIceDelivery) == 7 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 7 or player:getStorageValue(Storage.ExplorerSociety.TheButterflyHunt) == 16 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 16 or player:getStorageValue(Storage.ExplorerSociety.JoiningtheExplorers) == 4 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 4 then
-            npcHandler:say("The missions available for your rank are the {butterfly hunt}, {plant collection} and {ice delivery}.", cid)
+            npcHandler:say("The missions available for your rank are the {Butterfly hunt}, {Plant collection} and {Ice delivery}.", cid)
             npcHandler.topic[cid] = 0
         elseif player:getStorageValue(Storage.ExplorerSociety.ThePlantCollection) > 25 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) > 35 and player:getStorageValue(Storage.ExplorerSociety.TheOrcPowder) < 35 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) < 35 or player:getStorageValue(Storage.ExplorerSociety.ThePlantCollection) == 26 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 26 or player:getStorageValue(Storage.ExplorerSociety.TheLizardUrn) == 29  and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 29 or player:getStorageValue(Storage.ExplorerSociety.TheBonelordSecret) == 32 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 32 then
-            npcHandler:say("The missions available for your rank are {lizard urn}, {bonelord secrets} and {orc powder}.", cid)
+            npcHandler:say("The missions available for your rank are {Lizard Urn}, {Beholder secrets} and {Orc Powder}.", cid)
             npcHandler.topic[cid] = 0
         elseif player:getStorageValue(Storage.ExplorerSociety.TheOrcPowder) > 34 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) > 34 and player:getStorageValue(Storage.ExplorerSociety.TheRuneWritings) < 44 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) < 44 or player:getStorageValue(Storage.ExplorerSociety.TheOrcPowder) == 35 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 35 or player:getStorageValue(Storage.ExplorerSociety.TheElvenPoetry) == 38 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 38 or player:getStorageValue(Storage.ExplorerSociety.TheMemoryStone) == 41 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 41 then
-            npcHandler:say("The missions available for your rank are {elven poetry}, {memory stone} and {rune writings}.", cid)
+            npcHandler:say("The missions available for your rank are {Elven Poetry}, {Memory Stone} and {Rune Writings}.", cid)
             npcHandler.topic[cid] = 0
         elseif player:getStorageValue(Storage.ExplorerSociety.TheRuneWritings) == 44 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 44 then
             npcHandler:say("The explorer society needs a great deal of help in the research of astral travel. Are you willing to help?", cid)
@@ -106,7 +106,7 @@ local function creatureSayCallback(cid, type, msg)
         -- PICKAXE MISSION
 
         -- ICE DELIVERY
-    elseif msgcontains(msg, "ice delivery") then
+    elseif msgcontains(msg, "ice") or msgcontains(msg, "delivery") then
         if player:getStorageValue(Storage.ExplorerSociety.JoiningtheExplorers) == 4 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 4 then
             npcHandler:say({
                 "Our finest minds came up with the theory that deep beneath the ice island of Folda ice can be found that is ancient. To prove this theory we would need a sample of the aforesaid ice ...",
@@ -121,7 +121,7 @@ local function creatureSayCallback(cid, type, msg)
         -- ICE DELIVERY
 
         -- BUTTERFLY HUNT
-    elseif msgcontains(msg, "butterfly hunt") then
+    elseif msgcontains(msg, "butterfly") or msgcontains(msg, "hunt") then
         if player:getStorageValue(Storage.ExplorerSociety.TheIceDelivery) == 7 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 7 then
             npcHandler:say("The mission asks you to collect some species of butterflies, are you interested?", cid)
             npcHandler.topic[cid] = 7
@@ -155,7 +155,7 @@ local function creatureSayCallback(cid, type, msg)
         end
         -- BUTTERFLY HUNT
         -- PLANT COLLECTION
-    elseif msgcontains(msg, "plant collection") then
+    elseif msgcontains(msg, "plant") or msgcontains(msg, "collection") then
         if player:getStorageValue(Storage.ExplorerSociety.TheButterflyHunt) == 16 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 16 then
             npcHandler:say("In this mission we require you to get us some plant samples from Tiquandan plants. Would you like to fulfil this mission?", cid)
             npcHandler.topic[cid] = 11
@@ -184,7 +184,7 @@ local function creatureSayCallback(cid, type, msg)
         -- PLANT COLLECTION
 
         -- LIZARD URN
-    elseif msgcontains(msg, "lizard urn") then
+    elseif msgcontains(msg, "urn") then
         if player:getStorageValue(Storage.ExplorerSociety.ThePlantCollection) == 26 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 26 then
             npcHandler:say("The explorer society would like to acquire an ancient urn which is some sort of relic to the lizard people of Tiquanda. Would you like to accept this mission?", cid)
             npcHandler.topic[cid] = 15
@@ -194,23 +194,23 @@ local function creatureSayCallback(cid, type, msg)
         end
         -- LIZARD URN
 
-        -- BONELORDS
-    elseif msgcontains(msg, "bonelord secrets") then
+        -- BEHOLDERS
+    elseif msgcontains(msg, "beholder") or msgcontains(msg, "secrets") then
         if player:getStorageValue(Storage.ExplorerSociety.TheLizardUrn) == 29  and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 29 then
             npcHandler:say({
-                "We want to learn more about the ancient race of bonelords. We believe the black pyramid north east of Darashia was originally built by them ...",
-                "We ask you to explore the ruins of the black pyramid and look for any signs that prove our theory. You might probably find some document with the numeric bonelord language ...",
+                "We want to learn more about the ancient race of beholders. We believe the black pyramid north east of Darashia was originally built by them ...",
+                "We ask you to explore the ruins of the black pyramid and look for any signs that prove our theory. You might probably find some document with the numeric beholder language ...",
                 "That would be sufficient proof. Would you like to accept this mission?"
             }, cid)
             npcHandler.topic[cid] = 17
         elseif player:getStorageValue(Storage.ExplorerSociety.TheBonelordSecret) == 31 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 30 then
-            npcHandler:say("Have you found any proof that the pyramid was built by bonelords?", cid)
+            npcHandler:say("Have you found any proof that the pyramid was built by beholders?", cid)
             npcHandler.topic[cid] = 18
         end
-        -- BONELORDS
+        -- BEHOLDERS
 
         -- ORC POWDER
-    elseif msgcontains(msg, "orc powder") then
+    elseif msgcontains(msg, "orc") or msgcontains(msg, "powder") then
         if player:getStorageValue(Storage.ExplorerSociety.TheBonelordSecret) == 32 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 32 then
             npcHandler:say({
                 "It is commonly known that orcs of Uldereks Rock use some sort of powder to increase the fierceness of their war wolves and berserkers ...",
@@ -225,7 +225,7 @@ local function creatureSayCallback(cid, type, msg)
         -- ORC POWDER
 
         -- ELVEN POETRY
-    elseif msgcontains(msg, "elven poetry") then
+    elseif msgcontains(msg, "elven") or msgcontains(msg, "poetry") then
         if player:getStorageValue(Storage.ExplorerSociety.TheOrcPowder) == 35 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 35 then
             npcHandler:say({
                 "Some high ranking members would like to study elven poetry. They want the rare book 'Songs of the Forest' ...",
@@ -239,7 +239,7 @@ local function creatureSayCallback(cid, type, msg)
         -- ELVEN POETRY
 
         -- MEMORY STONE
-    elseif msgcontains(msg, "memory stone") then
+    elseif msgcontains(msg, "memory") then
         if player:getStorageValue(Storage.ExplorerSociety.TheElvenPoetry) == 38 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 38 then
             npcHandler:say({
                 "We acquired some knowledge about special magic stones. Some lost civilisations used it to store knowledge and lore, just like we use books ...",
@@ -254,7 +254,7 @@ local function creatureSayCallback(cid, type, msg)
         -- MEMORY STONE
 
         -- RUNE WRITINGS
-    elseif msgcontains(msg, "rune writings") then
+    elseif msgcontains(msg, "rune") or msgcontains(msg, "writings") then
         if player:getStorageValue(Storage.ExplorerSociety.TheMemoryStone) == 41 and player:getStorageValue(Storage.ExplorerSociety.QuestLine) == 41 then
             npcHandler:say({
                 "We would like to study some ancient runes that were used by the lizard race. We suspect some relation of the lizards to the founders of Ankrahmun ...",
@@ -398,7 +398,7 @@ local function creatureSayCallback(cid, type, msg)
             end
             -- LIZARD URN
 
-            -- BONELORDS
+            -- BEHOLDERS
         elseif npcHandler.topic[cid] == 17 then
             player:setStorageValue(Storage.ExplorerSociety.TheBonelordSecret, 30)
 			player:setStorageValue(Storage.ExplorerSociety.QuestLine, 30)
@@ -415,7 +415,7 @@ local function creatureSayCallback(cid, type, msg)
                 npcHandler:say("You did it! Excellent! The scientific world will be shaken by this discovery!", cid)
                 npcHandler.topic[cid] = 0
             end
-            -- BONELORDS
+            -- BEHOLDERS
 
             -- ORC POWDER
         elseif npcHandler.topic[cid] == 19 then
@@ -428,7 +428,7 @@ local function creatureSayCallback(cid, type, msg)
             }, cid)
             npcHandler.topic[cid] = 0
         elseif npcHandler.topic[cid] == 20 then
-            if player:removeItem(5940, 1) then
+            if player:removeItem(4849, 1) then
                 player:setStorageValue(Storage.ExplorerSociety.TheOrcPowder, 35)
 				player:setStorageValue(Storage.ExplorerSociety.QuestLine, 35)
                 npcHandler:say("You really got it? Amazing! Thank you for your efforts.", cid)
@@ -579,13 +579,13 @@ local function creatureSayCallback(cid, type, msg)
         -- ANSWER NO
 
         -- SKULL OF RATHA / GIANT SMITHHAMMER
-    elseif msgcontains(msg, "skull of ratha") and player:getStorageValue(Storage.ExplorerSociety.skullofratha) < 1 then
+    elseif msgcontains(msg, "skull") or msgcontains(msg, "ratha") and player:getStorageValue(Storage.ExplorerSociety.skullofratha) < 1 then
         npcHandler:say({
             "Ratha was a great explorer and even greater ladies' man. Sadly he never returned from a visit to the amazons. Probably he is dead ...",
             "The society offers a substantial reward for the retrieval of Ratha or his remains. Do you have any news about Ratha?"
         }, cid)
         npcHandler.topic[cid] = 33
-    elseif msgcontains(msg, "giant smithhammer") and player:getStorageValue(Storage.ExplorerSociety.giantsmithhammer) < 1 then
+    elseif msgcontains(msg, "giant") and player:getStorageValue(Storage.ExplorerSociety.giantsmithhammer) < 1 then
         npcHandler:say("The explorer society is looking for a genuine giant smith hammer for our collection. It is rumoured the cyclopses of the Plains of Havoc might be using one. Did you by chance obtain such a hammer?", cid)
         npcHandler.topic[cid] = 34
         -- SKULL OF RATHA / GIANT SMITHHAMMER

--- a/data/npc/scripts/Puffels.lua
+++ b/data/npc/scripts/Puffels.lua
@@ -7,6 +7,46 @@ function onCreatureDisappear(cid) npcHandler:onCreatureDisappear(cid) end
 function onCreatureSay(cid, type, msg) npcHandler:onCreatureSay(cid, type, msg) end
 function onThink() npcHandler:onThink() end
 
+local node1 = keywordHandler:addKeyword({'berserk'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Berserk for 2500 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'berserk',vocation = {4,8}, price = 2500, level = 35})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'ethereal spear'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Ethereal Spear for 1100 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'ethereal spear',vocation = {3,7}, price = 1100, level = 23})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'energy strike'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Energy Strike for 800 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'energy strike',vocation = {1,2}, price = 800, level = 12})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'flame strike'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Flame Strike for 800 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'flame strike',vocation = {1,2}, price = 800, level = 11})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'force strike'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Force Strike for 600 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'force strike',vocation = {1,2}, price = 600, level = 11})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'haste'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Haste for 600 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'haste',vocation = {1,2,3,4}, price = 600, level = 14})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'levitate'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Levitate for 500 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'levitate',vocation = {1,2,3,4}, price = 500, level = 12})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'magic rope'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Magic Rope for 200 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'magic rope',vocation = {1,2,3,4}, price = 200, level = 9})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'whirlwind throw'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Whirlwind Throw for 800 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'whirlwind throw',vocation = 4, price = 800, level = 15})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+
+
+
+
 keywordHandler:addKeyword({'job'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I have to teach the spells of least importance to some fools."})
 keywordHandler:addKeyword({'name'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I am Magister Puffels, any problem with that?"})
 keywordHandler:addKeyword({'time'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "Where might I hide a watch, you fool?"})

--- a/data/npc/scripts/Ursula.lua
+++ b/data/npc/scripts/Ursula.lua
@@ -9,7 +9,7 @@ function onThink() npcHandler:onThink() end
 
 
 local node1 = keywordHandler:addKeyword({'animate dead'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Animate Dead for 600 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'animate dead',vocation = {1,2}, price = 600, level = 27})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'animate dead', vocation = {1,2}, price = 600, level = 27})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'conjure bolt'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Conjure Bolt for 750 gp?'})
@@ -17,40 +17,41 @@ node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, p
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'conjure piercing bolt'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Conjure Piercing Bolt Dead for 850 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure piercing bolt'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure piercing bolt', price = 850})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'conjure sniper arrow'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Conjure Sniper Arrow for 800 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure sniper arrow'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure sniper arrow', price = 800})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'desintegrate'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Desintegrate for 900 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'desintegrate'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'desintegrate', price = 900})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'fireball'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Fireball for 800 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'fireball'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'fireball', price = 800})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'groundshaker'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Groundshaker for 1500 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'groundshaker'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'groundshaker', price = 1500})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'heal friend'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Heal Friend for 800 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'heal friend'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'heal friend', price = 800})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'poison bomb'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Poison Bomb for 1000 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'poison bomb'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'poison bomb', price = 1000})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'heal friend'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Heal Friend for 900 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'heal friend'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'heal friend', price = 900})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'strong haste'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Strong Haste for 1300 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'strong haste'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'strong haste', price = 1300})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
 
 
 

--- a/data/npc/scripts/Ursula.lua
+++ b/data/npc/scripts/Ursula.lua
@@ -7,6 +7,54 @@ function onCreatureDisappear(cid) npcHandler:onCreatureDisappear(cid) end
 function onCreatureSay(cid, type, msg) npcHandler:onCreatureSay(cid, type, msg) end
 function onThink() npcHandler:onThink() end
 
+
+local node1 = keywordHandler:addKeyword({'animate dead'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Animate Dead for 600 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'animate dead',vocation = {1,2}, price = 600, level = 27})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'conjure bolt'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Conjure Bolt for 750 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure bolt', price = 750, level = 17})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'conjure piercing bolt'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Conjure Piercing Bolt Dead for 850 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure piercing bolt'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'conjure sniper arrow'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Conjure Sniper Arrow for 800 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'conjure sniper arrow'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'desintegrate'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Desintegrate for 900 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'desintegrate'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'fireball'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Fireball for 800 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'fireball'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'groundshaker'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Groundshaker for 1500 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'groundshaker'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'heal friend'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Heal Friend for 800 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'heal friend'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'poison bomb'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Poison Bomb for 1000 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'poison bomb'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'heal friend'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Heal Friend for 900 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'heal friend'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'strong haste'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Strong Haste for 1300 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'strong haste'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+
+
+
 keywordHandler:addKeyword({'job'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I teach some basic spells."})
 keywordHandler:addKeyword({'name'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I am Ursula."})
 keywordHandler:addKeyword({'time'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "Sorry, I don't own a watch."})

--- a/data/npc/scripts/Zoltan.lua
+++ b/data/npc/scripts/Zoltan.lua
@@ -8,28 +8,29 @@ function onCreatureSay(cid, type, msg) npcHandler:onCreatureSay(cid, type, msg) 
 function onThink() npcHandler:onThink() end
 
 local node1 = keywordHandler:addKeyword({'energy bomb'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Energy Bomb for 880 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'energy bomb'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'energy bomb', price = 880})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'fierce berserk'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Fierce Berserk for 5000 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'fierce berserk'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'fierce berserk', price = 5000})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'mass healing'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Mass Healing for 2200 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'mass healing'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'mass healing', price = 2200})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'paralyze'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Paralyze for 1900 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'paralyze'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'paralyze', price = 1900})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'poison storm'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Poison Storm for 3400 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'poison storm'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'poison storm', price = 3400})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
 
 local node1 = keywordHandler:addKeyword({'ultimate explosion'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Ultimate Explosion for 8000 gp?'})
-node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'ultimate explosion'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'ultimate explosion', price = 8000})
 node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
 
 keywordHandler:addKeyword({'job'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I am a teacher of the most powerful spells in Tibia."})
 keywordHandler:addKeyword({'name'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I am known in this world as Zoltan."})

--- a/data/npc/scripts/Zoltan.lua
+++ b/data/npc/scripts/Zoltan.lua
@@ -7,6 +7,30 @@ function onCreatureDisappear(cid) npcHandler:onCreatureDisappear(cid) end
 function onCreatureSay(cid, type, msg) npcHandler:onCreatureSay(cid, type, msg) end
 function onThink() npcHandler:onThink() end
 
+local node1 = keywordHandler:addKeyword({'energy bomb'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Energy Bomb for 880 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'energy bomb'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'fierce berserk'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Fierce Berserk for 5000 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'fierce berserk'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'mass healing'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Mass Healing for 2200 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'mass healing'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'paralyze'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Paralyze for 1900 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'paralyze'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'poison storm'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Poison Storm for 3400 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'poison storm'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
+local node1 = keywordHandler:addKeyword({'ultimate explosion'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Would you like to learn Ultimate Explosion for 8000 gp?'})
+node1:addChildKeyword({'yes'}, StdModule.learnSpell, {npcHandler = npcHandler, premium = false, spellName = 'ultimate explosion'})
+node1:addChildKeyword({'no'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = 'Cant you handle the power of the spell?', reset = true})
+
 keywordHandler:addKeyword({'job'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I am a teacher of the most powerful spells in Tibia."})
 keywordHandler:addKeyword({'name'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "I am known in this world as Zoltan."})
 keywordHandler:addKeyword({'king'}, StdModule.say, {npcHandler = npcHandler, onlyFocus = true, text = "King Tibianus III was the founder of our academy."})

--- a/data/world/global-house.xml
+++ b/data/world/global-house.xml
@@ -283,13 +283,13 @@
 	<house name="Rosebud B" houseid="285" entryx="32263" entryy="31698" entryz="7" rent="1000" townid="4" size="23" />
 	<house name="Rosebud C" houseid="286" entryx="32272" entryy="31698" entryz="7" rent="1340" townid="4" size="26" />
 	<house name="Nordic Stronghold" houseid="287" entryx="32297" entryy="31675" entryz="7" rent="18400" guildhall="true" townid="4" size="335" />
-	<house name="Seawatch" houseid="288" entryx="32520" entryy="31600" entryz="7" rent="25010" guildhall="true" townid="4" size="346" />
+	<house name="Seawatch" houseid="288" entryx="32520" entryy="31600" entryz="7" rent="25010" guildhall="true" townid="4" size="347" />
 	<house name="Northport Village 5" houseid="289" entryx="32503" entryy="31605" entryz="7" rent="1805" townid="4" size="26" />
 	<house name="Northport Village 4" houseid="290" entryx="32490" entryy="31602" entryz="7" rent="2630" townid="4" size="42" />
 	<house name="Northport Village 6" houseid="291" entryx="32502" entryy="31606" entryz="7" rent="2135" townid="4" size="31" />
 	<house name="Northport Village 1" houseid="293" entryx="32482" entryy="31614" entryz="7" rent="1475" townid="4" size="20" />
 	<house name="Northport Village 2" houseid="294" entryx="32482" entryy="31609" entryz="7" rent="1475" townid="4" size="20" />
-	<house name="Northport Clanhall" houseid="295" entryx="32468" entryy="31614" entryz="7" rent="9810" guildhall="true" townid="4" size="122" />
+	<house name="Northport Clanhall" houseid="295" entryx="32468" entryy="31614" entryz="7" rent="9810" guildhall="true" townid="4" size="121" />
 	<house name="Northport Village 3" houseid="296" entryx="32482" entryy="31611" entryz="6" rent="5435" townid="4" size="91" />
 	<house name="Senja Clanhall" houseid="297" entryx="32168" entryy="31664" entryz="7" rent="10575" guildhall="true" townid="4" size="161" />
 	<house name="Senja Village 2" houseid="298" entryx="32161" entryy="31664" entryz="7" rent="795" townid="4" size="15" />

--- a/data/world/global-spawn.xml
+++ b/data/world/global-spawn.xml
@@ -14805,6 +14805,9 @@
 		<monster name="cobra" x="-1" y="1" z="7" spawntime="60" />
 		<monster name="carniphila" x="1" y="1" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32954" centery="32513" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32967" centery="32513" centerz="7" radius="1">
 		<monster name="centipede" x="0" y="1" z="7" spawntime="60" />
 	</spawn>
@@ -14855,6 +14858,9 @@
 	</spawn>
 	<spawn centerx="32972" centery="32520" centerz="7" radius="1">
 		<monster name="centipede" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32975" centery="32520" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32982" centery="32520" centerz="7" radius="1">
 		<monster name="cobra" x="-1" y="0" z="7" spawntime="60" />
@@ -14908,6 +14914,9 @@
 		<monster name="sibang" x="-1" y="3" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32945" centery="32524" centerz="7" radius="1" />
+	<spawn centerx="32960" centery="32524" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="33154" centery="32524" centerz="7" radius="2">
 		<monster name="nomad" x="1" y="-1" z="7" spawntime="60" />
 	</spawn>
@@ -14950,6 +14959,9 @@
 		<monster name="cobra" x="0" y="-1" z="7" spawntime="60" />
 		<monster name="terror bird" x="1" y="-1" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32967" centery="32530" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32785" centery="32531" centerz="7" radius="4">
 		<monster name="sibang" x="1" y="-3" z="7" spawntime="60" />
 		<monster name="sibang" x="-3" y="-1" z="7" spawntime="60" />
@@ -14974,6 +14986,9 @@
 	</spawn>
 	<spawn centerx="32940" centery="32532" centerz="7" radius="1">
 		<monster name="terror bird" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32957" centery="32532" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32990" centery="32532" centerz="7" radius="1">
 		<monster name="terror bird" x="1" y="0" z="7" spawntime="60" />
@@ -15015,6 +15030,12 @@
 	</spawn>
 	<spawn centerx="32996" centery="32536" centerz="7" radius="1">
 		<monster name="centipede" x="0" y="1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32806" centery="32537" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32908" centery="32537" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32940" centery="32537" centerz="7" radius="1">
 		<monster name="carniphila" x="1" y="0" z="7" spawntime="60" />
@@ -15174,6 +15195,9 @@
 	<spawn centerx="32944" centery="32555" centerz="7" radius="1">
 		<monster name="behemoth" x="0" y="1" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32775" centery="32556" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32965" centery="32556" centerz="7" radius="1">
 		<monster name="cobra" x="1" y="-1" z="7" spawntime="60" />
 	</spawn>
@@ -15236,6 +15260,9 @@
 	<spawn centerx="32988" centery="32558" centerz="7" radius="1" />
 	<spawn centerx="32378" centery="32559" centerz="7" radius="1">
 		<monster name="flamingo" x="0" y="-1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32958" centery="32559" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32999" centery="32559" centerz="7" radius="1">
 		<monster name="tiger" x="1" y="0" z="7" spawntime="60" />
@@ -15350,6 +15377,7 @@
 		<monster name="sibang" x="3" y="-1" z="7" spawntime="60" />
 		<monster name="kongra" x="-2" y="0" z="7" spawntime="60" />
 		<monster name="sibang" x="4" y="1" z="7" spawntime="60" />
+		<monster name="Red Butterfly" x="1" y="2" z="7" spawntime="60" />
 		<monster name="kongra" x="2" y="4" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32913" centery="32564" centerz="7" radius="4">
@@ -15365,6 +15393,9 @@
 	</spawn>
 	<spawn centerx="32974" centery="32564" centerz="7" radius="1">
 		<monster name="cobra" x="1" y="-1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32985" centery="32564" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32341" centery="32565" centerz="7" radius="1">
 		<monster name="wasp" x="0" y="-1" z="7" spawntime="60" />
@@ -15424,6 +15455,9 @@
 	</spawn>
 	<spawn centerx="32378" centery="32567" centerz="7" radius="1">
 		<monster name="snake" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32746" centery="32567" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32332" centery="32568" centerz="7" radius="1">
 		<monster name="rat" x="0" y="1" z="7" spawntime="60" />
@@ -15762,6 +15796,9 @@
 	<spawn centerx="32367" centery="32593" centerz="7" radius="1">
 		<monster name="flamingo" x="1" y="1" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32747" centery="32593" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32991" centery="32593" centerz="7" radius="1" />
 	<spawn centerx="32354" centery="32594" centerz="7" radius="1">
 		<monster name="chicken" x="0" y="-1" z="7" spawntime="60" />
@@ -15773,6 +15810,7 @@
 	</spawn>
 	<spawn centerx="32883" centery="32594" centerz="7" radius="4">
 		<monster name="tarantula" x="2" y="-2" z="7" spawntime="60" />
+		<monster name="Blue Butterfly" x="4" y="4" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32904" centery="32594" centerz="7" radius="4">
 		<monster name="wasp" x="-4" y="-3" z="7" spawntime="60" />
@@ -15794,6 +15832,9 @@
 	</spawn>
 	<spawn centerx="32361" centery="32597" centerz="7" radius="1">
 		<monster name="Blue Butterfly" x="-1" y="-1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32675" centery="32597" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32828" centery="32597" centerz="7" radius="3">
 		<monster name="kongra" x="1" y="1" z="7" spawntime="60" />
@@ -15817,6 +15858,9 @@
 		<monster name="snake" x="-2" y="-2" z="7" spawntime="60" />
 		<monster name="snake" x="2" y="0" z="7" spawntime="60" />
 		<monster name="snake" x="-2" y="2" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32891" centery="32599" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32963" centery="32599" centerz="7" radius="3">
 		<monster name="sibang" x="-3" y="-2" z="7" spawntime="60" />
@@ -15967,8 +16011,10 @@
 		<monster name="nomad" x="0" y="1" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32676" centery="32610" centerz="7" radius="3">
+		<monster name="Blue Butterfly" x="-2" y="0" z="7" spawntime="60" />
 		<monster name="slime" x="0" y="0" z="7" spawntime="60" />
 		<monster name="swamp troll" x="3" y="0" z="7" spawntime="60" />
+		<monster name="Blue Butterfly" x="-3" y="1" z="7" spawntime="60" />
 		<monster name="swamp troll" x="-2" y="1" z="7" spawntime="60" />
 		<monster name="swamp troll" x="3" y="2" z="7" spawntime="60" />
 	</spawn>
@@ -16002,6 +16048,9 @@
 	<spawn centerx="32624" centery="32614" centerz="7" radius="2">
 		<monster name="crocodile" x="1" y="-1" z="7" spawntime="60" />
 		<monster name="crocodile" x="-1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32672" centery="32614" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32755" centery="32614" centerz="7" radius="5">
 		<monster name="terror bird" x="-4" y="-4" z="7" spawntime="60" />
@@ -16106,6 +16155,7 @@
 		<monster name="centipede" x="1" y="2" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32889" centery="32620" centerz="7" radius="4">
+		<monster name="Red Butterfly" x="-4" y="-2" z="7" spawntime="60" />
 		<monster name="bug" x="3" y="-1" z="7" spawntime="60" />
 		<monster name="bug" x="-2" y="1" z="7" spawntime="60" />
 		<monster name="wasp" x="1" y="4" z="7" spawntime="60" />
@@ -16145,6 +16195,9 @@
 		<monster name="crocodile" x="1" y="-1" z="7" spawntime="60" />
 		<monster name="crocodile" x="-2" y="0" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32668" centery="32626" centerz="7" radius="1">
+		<monster name="Yellow Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32910" centery="32626" centerz="7" radius="4">
 		<monster name="bug" x="-2" y="-4" z="7" spawntime="60" />
 		<monster name="bug" x="0" y="-2" z="7" spawntime="60" />
@@ -16165,6 +16218,9 @@
 	</spawn>
 	<spawn centerx="32391" centery="32629" centerz="7" radius="1">
 		<monster name="bat" x="-1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32645" centery="32629" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32800" centery="32629" centerz="7" radius="5">
 		<monster name="wasp" x="2" y="-5" z="7" spawntime="60" />
@@ -16234,6 +16290,9 @@
 		<monster name="cobra" x="-3" y="-1" z="7" spawntime="60" />
 		<monster name="wasp" x="2" y="-1" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32868" centery="32636" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32627" centery="32637" centerz="7" radius="2">
 		<monster name="terror bird" x="0" y="2" z="7" spawntime="60" />
 	</spawn>
@@ -16259,6 +16318,9 @@
 	</spawn>
 	<spawn centerx="33194" centery="32641" centerz="7" radius="2">
 		<monster name="nomad" x="1" y="-1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32625" centery="32642" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32844" centery="32643" centerz="7" radius="4">
 		<monster name="centipede" x="-3" y="-2" z="7" spawntime="60" />
@@ -16431,8 +16493,12 @@
 	<spawn centerx="32854" centery="32660" centerz="7" radius="1">
 		<monster name="centipede" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32956" centery="32660" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32590" centery="32661" centerz="7" radius="2">
 		<monster name="centipede" x="-2" y="2" z="7" spawntime="60" />
+		<monster name="butterfly" x="1" y="2" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32597" centery="32661" centerz="7" radius="2">
 		<monster name="centipede" x="0" y="1" z="7" spawntime="60" />
@@ -16691,6 +16757,9 @@
 		<monster name="elephant" x="2" y="-3" z="7" spawntime="60" />
 		<monster name="elephant" x="-1" y="2" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32701" centery="32683" centerz="7" radius="1">
+		<monster name="Yellow Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32777" centery="32683" centerz="7" radius="5">
 		<monster name="tarantula" x="5" y="-2" z="7" spawntime="60" />
 		<monster name="tarantula" x="-2" y="1" z="7" spawntime="60" />
@@ -16710,7 +16779,6 @@
 		<monster name="snake" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32743" centery="32684" centerz="7" radius="5">
-		<monster name="carniphila" x="-1" y="-1" z="7" spawntime="60" />
 		<monster name="bug" x="-2" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32961" centery="32684" centerz="7" radius="3">
@@ -16745,6 +16813,10 @@
 	</spawn>
 	<spawn centerx="32620" centery="32689" centerz="7" radius="2">
 		<monster name="centipede" x="-1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32664" centery="32689" centerz="7" radius="1">
+		<monster name="butterfly" x="0" y="0" z="7" spawntime="60" />
+		<monster name="butterfly" x="1" y="1" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32837" centery="32689" centerz="7" radius="3">
 		<monster name="bug" x="-1" y="-3" z="7" spawntime="60" />
@@ -16785,6 +16857,10 @@
 	<spawn centerx="32571" centery="32692" centerz="7" radius="2">
 		<monster name="slime" x="0" y="2" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32661" centery="32692" centerz="7" radius="1">
+		<monster name="butterfly" x="0" y="0" z="7" spawntime="60" />
+		<monster name="butterfly" x="-1" y="1" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="33073" centery="32692" centerz="7" radius="3">
 		<monster name="dragon" x="1" y="-1" z="7" spawntime="60" />
 		<monster name="dragon" x="0" y="3" z="7" spawntime="60" />
@@ -16814,9 +16890,7 @@
 	<spawn centerx="32758" centery="32696" centerz="7" radius="5">
 		<monster name="wasp" x="2" y="-4" z="7" spawntime="60" />
 		<monster name="wasp" x="2" y="-3" z="7" spawntime="60" />
-		<monster name="tarantula" x="-2" y="0" z="7" spawntime="60" />
 		<monster name="bug" x="1" y="1" z="7" spawntime="60" />
-		<monster name="carniphila" x="-3" y="4" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32944" centery="32696" centerz="7" radius="2">
 		<monster name="carniphila" x="2" y="2" z="7" spawntime="60" />
@@ -16870,7 +16944,6 @@
 		<monster name="fire elemental" x="-11" y="1" z="7" spawntime="60" />
 		<monster name="dragon lord" x="-5" y="5" z="7" spawntime="60" />
 		<monster name="fire elemental" x="6" y="5" z="7" spawntime="60" />
-		<monster name="dragon lord" x="8" y="6" z="7" spawntime="60" />
 		<monster name="fire elemental" x="-7" y="8" z="7" spawntime="60" />
 		<monster name="behemoth" x="1" y="8" z="7" spawntime="60" />
 		<monster name="fire elemental" x="-2" y="10" z="7" spawntime="60" />
@@ -16895,6 +16968,12 @@
 	</spawn>
 	<spawn centerx="32862" centery="32698" centerz="7" radius="3">
 		<monster name="snake" x="0" y="-1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32907" centery="32698" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32909" centery="32698" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="31834" centery="32699" centerz="7" radius="30">
 		<monster name="quara mantassin" x="10" y="-11" z="7" spawntime="60" />
@@ -16959,6 +17038,9 @@
 	<spawn centerx="32569" centery="32703" centerz="7" radius="2">
 		<monster name="slime" x="-1" y="-1" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32711" centery="32703" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32853" centery="32703" centerz="7" radius="3">
 		<monster name="tiger" x="-1" y="-2" z="7" spawntime="60" />
 		<monster name="snake" x="2" y="0" z="7" spawntime="60" />
@@ -16967,6 +17049,9 @@
 		<monster name="spider" x="2" y="-3" z="7" spawntime="60" />
 		<monster name="spider" x="4" y="-1" z="7" spawntime="60" />
 		<monster name="spider" x="-3" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32843" centery="32704" centerz="7" radius="1">
+		<monster name="butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32940" centery="32704" centerz="7" radius="2">
 		<monster name="carniphila" x="1" y="-1" z="7" spawntime="60" />
@@ -16977,6 +17062,9 @@
 		<monster name="bat" x="-2" y="0" z="7" spawntime="60" />
 		<monster name="bat" x="0" y="2" z="7" spawntime="60" />
 		<monster name="bat" x="2" y="2" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32591" centery="32705" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32955" centery="32705" centerz="7" radius="3">
 		<monster name="flamingo" x="0" y="-2" z="7" spawntime="60" />
@@ -17020,11 +17108,8 @@
 		<npc name="Braden" x="1" y="-1" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32746" centery="32709" centerz="7" radius="5">
-		<monster name="tiger" x="5" y="-4" z="7" spawntime="60" />
-		<monster name="tiger" x="2" y="-2" z="7" spawntime="60" />
 		<monster name="bug" x="1" y="-1" z="7" spawntime="60" />
 		<monster name="spider" x="-4" y="0" z="7" spawntime="60" />
-		<monster name="tarantula" x="-2" y="1" z="7" spawntime="60" />
 		<monster name="Parrot" x="-1" y="5" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32841" centery="32709" centerz="7" radius="3">
@@ -17190,6 +17275,9 @@
 		<monster name="centipede" x="2" y="2" z="7" spawntime="60" />
 		<monster name="centipede" x="2" y="3" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32645" centery="32723" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="33261" centery="32724" centerz="7" radius="2">
 		<monster name="nomad" x="2" y="-2" z="7" spawntime="60" />
 	</spawn>
@@ -17228,6 +17316,9 @@
 	<spawn centerx="32925" centery="32727" centerz="7" radius="2">
 		<monster name="flamingo" x="0" y="-2" z="7" spawntime="60" />
 		<monster name="flamingo" x="1" y="2" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32582" centery="32729" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32670" centery="32729" centerz="7" radius="1">
 		<npc name="Angus" x="0" y="1" z="7" spawntime="60" />
@@ -17349,6 +17440,9 @@
 	</spawn>
 	<spawn centerx="32936" centery="32738" centerz="7" radius="2">
 		<monster name="hydra" x="1" y="1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32993" centery="32738" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32959" centery="32739" centerz="7" radius="2">
 		<monster name="elephant" x="2" y="1" z="7" spawntime="60" />
@@ -17625,6 +17719,9 @@
 	<spawn centerx="32863" centery="32766" centerz="7" radius="1">
 		<monster name="elephant" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32866" centery="32766" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32450" centery="32767" centerz="7" radius="4">
 		<monster name="black sheep" x="2" y="-3" z="7" spawntime="60" />
 		<monster name="black sheep" x="-3" y="-2" z="7" spawntime="60" />
@@ -17634,6 +17731,11 @@
 	</spawn>
 	<spawn centerx="32760" centery="32767" centerz="7" radius="1">
 		<monster name="flamingo" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32816" centery="32767" centerz="7" radius="1">
+		<monster name="butterfly" x="0" y="0" z="7" spawntime="60" />
+		<monster name="butterfly" x="-1" y="1" z="7" spawntime="60" />
+		<monster name="butterfly" x="0" y="1" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32938" centery="32767" centerz="7" radius="3">
 		<monster name="spider" x="1" y="-2" z="7" spawntime="60" />
@@ -17666,6 +17768,9 @@
 	<spawn centerx="32747" centery="32769" centerz="7" radius="1">
 		<monster name="snake" x="1" y="0" z="7" spawntime="60" />
 		<monster name="butterfly" x="0" y="1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32815" centery="32769" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32949" centery="32769" centerz="7" radius="2">
 		<monster name="elephant" x="0" y="0" z="7" spawntime="60" />
@@ -17750,6 +17855,10 @@
 		<monster name="lizard templar" x="2" y="-3" z="7" spawntime="60" />
 		<monster name="lizard templar" x="-2" y="-1" z="7" spawntime="60" />
 		<monster name="lizard templar" x="3" y="2" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32559" centery="32776" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="-1" z="7" spawntime="60" />
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32793" centery="32776" centerz="7" radius="1">
 		<monster name="tarantula" x="1" y="0" z="7" spawntime="60" />
@@ -17893,7 +18002,9 @@
 	<spawn centerx="32722" centery="32793" centerz="7" radius="30">
 		<monster name="wasp" x="-12" y="-4" z="7" spawntime="60" />
 		<monster name="tarantula" x="-19" y="1" z="7" spawntime="60" />
+		<monster name="butterfly" x="-20" y="15" z="7" spawntime="60" />
 		<monster name="snake" x="0" y="15" z="7" spawntime="60" />
+		<monster name="butterfly" x="-16" y="16" z="7" spawntime="60" />
 		<monster name="bug" x="-22" y="18" z="7" spawntime="60" />
 		<monster name="snake" x="9" y="18" z="7" spawntime="60" />
 		<monster name="poison spider" x="-20" y="19" z="7" spawntime="60" />
@@ -17948,9 +18059,18 @@
 	<spawn centerx="32863" centery="32799" centerz="7" radius="1">
 		<monster name="wasp" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32649" centery="32800" centerz="7" radius="1">
+		<monster name="butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32847" centery="32801" centerz="7" radius="1">
+		<monster name="Yellow Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32982" centery="32801" centerz="7" radius="2">
 		<monster name="lizard snakecharmer" x="0" y="-2" z="7" spawntime="60" />
 		<monster name="lizard sentinel" x="-2" y="1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32648" centery="32802" centerz="7" radius="1">
+		<monster name="butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32865" centery="32802" centerz="7" radius="1">
 		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
@@ -17967,7 +18087,9 @@
 		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32900" centery="32804" centerz="7" radius="30">
+		<monster name="Red Butterfly" x="-17" y="-3" z="7" spawntime="60" />
 		<monster name="poison spider" x="-29" y="4" z="7" spawntime="60" />
+		<monster name="Purple Butterfly" x="30" y="10" z="7" spawntime="60" />
 		<monster name="centipede" x="-5" y="26" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32989" centery="32804" centerz="7" radius="3">
@@ -17990,6 +18112,9 @@
 	</spawn>
 	<spawn centerx="32345" centery="32807" centerz="7" radius="1">
 		<npc name="Frederik" x="0" y="1" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32651" centery="32808" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32758" centery="32808" centerz="7" radius="1">
 		<monster name="spider" x="1" y="0" z="7" spawntime="60" />
@@ -18024,6 +18149,9 @@
 	</spawn>
 	<spawn centerx="32359" centery="32812" centerz="7" radius="1">
 		<npc name="Berenice" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32661" centery="32812" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32991" centery="32812" centerz="7" radius="2">
 		<monster name="lizard templar" x="1" y="0" z="7" spawntime="60" />
@@ -18069,6 +18197,9 @@
 	<spawn centerx="32777" centery="32817" centerz="7" radius="1">
 		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32597" centery="32818" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32613" centery="32818" centerz="7" radius="1">
 		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
 		<monster name="centipede" x="1" y="1" z="7" spawntime="60" />
@@ -18089,6 +18220,9 @@
 	</spawn>
 	<spawn centerx="32684" centery="32819" centerz="7" radius="1">
 		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32934" centery="32819" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32678" centery="32820" centerz="7" radius="1">
 		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
@@ -18147,8 +18281,8 @@
 	<spawn centerx="32317" centery="32824" centerz="7" radius="2">
 		<npc name="Tyrias" x="-1" y="-1" z="7" spawntime="60" />
 	</spawn>
-	<spawn centerx="32596" centery="32824" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
+	<spawn centerx="32550" centery="32824" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32839" centery="32824" centerz="7" radius="1">
 		<monster name="tiger" x="1" y="0" z="7" spawntime="60" />
@@ -18185,8 +18319,17 @@
 		<monster name="nomad" x="-3" y="-1" z="7" spawntime="60" />
 		<monster name="nomad" x="2" y="1" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32750" centery="32826" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32543" centery="32827" centerz="7" radius="1">
+		<monster name="butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32596" centery="32827" centerz="7" radius="1">
 		<monster name="spider" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32605" centery="32827" centerz="7" radius="1">
+		<monster name="Yellow Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32636" centery="32827" centerz="7" radius="1">
 		<monster name="snake" x="1" y="0" z="7" spawntime="60" />
@@ -18194,11 +18337,17 @@
 	<spawn centerx="32984" centery="32827" centerz="7" radius="2">
 		<monster name="spit nettle" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32533" centery="32828" centerz="7" radius="1">
+		<monster name="Yellow Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32669" centery="32828" centerz="7" radius="1">
 		<monster name="cobra" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32710" centery="32828" centerz="7" radius="1">
 		<monster name="cobra" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32747" centery="32828" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32958" centery="32828" centerz="7" radius="2">
 		<monster name="lizard templar" x="1" y="-2" z="7" spawntime="60" />
@@ -18246,6 +18395,9 @@
 	</spawn>
 	<spawn centerx="32578" centery="32831" centerz="7" radius="1">
 		<monster name="wasp" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32600" centery="32831" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32973" centery="32831" centerz="7" radius="2">
 		<monster name="lizard sentinel" x="2" y="-1" z="7" spawntime="60" />
@@ -18325,9 +18477,6 @@
 	<spawn centerx="32269" centery="32841" centerz="7" radius="1">
 		<npc name="Charlotta" x="-1" y="0" z="7" spawntime="60" />
 	</spawn>
-	<spawn centerx="32551" centery="32841" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
-	</spawn>
 	<spawn centerx="32932" centery="32841" centerz="7" radius="3">
 		<monster name="lizard sentinel" x="2" y="0" z="7" spawntime="60" />
 	</spawn>
@@ -18355,14 +18504,14 @@
 	<spawn centerx="32739" centery="32842" centerz="7" radius="1">
 		<monster name="tiger" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32755" centery="32842" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32844" centery="32842" centerz="7" radius="1">
 		<monster name="wasp" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32714" centery="32843" centerz="7" radius="1">
 		<monster name="snake" x="1" y="0" z="7" spawntime="60" />
-	</spawn>
-	<spawn centerx="32551" centery="32844" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32940" centery="32844" centerz="7" radius="3">
 		<monster name="lizard snakecharmer" x="1" y="0" z="7" spawntime="60" />
@@ -18377,9 +18526,6 @@
 		<monster name="spider" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32548" centery="32846" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
-	</spawn>
-	<spawn centerx="32614" centery="32846" centerz="7" radius="1">
 		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32640" centery="32846" centerz="7" radius="1">
@@ -18400,6 +18546,9 @@
 	<spawn centerx="32826" centery="32847" centerz="7" radius="1">
 		<monster name="spit nettle" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32709" centery="32848" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32966" centery="32848" centerz="7" radius="2">
 		<monster name="lizard snakecharmer" x="0" y="-1" z="7" spawntime="60" />
 	</spawn>
@@ -18418,9 +18567,6 @@
 	<spawn centerx="32544" centery="32850" centerz="7" radius="1">
 		<monster name="crab" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
-	<spawn centerx="32594" centery="32850" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
-	</spawn>
 	<spawn centerx="32920" centery="32850" centerz="7" radius="3">
 		<monster name="lizard sentinel" x="0" y="-1" z="7" spawntime="60" />
 		<monster name="lizard sentinel" x="1" y="3" z="7" spawntime="60" />
@@ -18433,6 +18579,13 @@
 	</spawn>
 	<spawn centerx="32684" centery="32851" centerz="7" radius="1">
 		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32703" centery="32851" centerz="7" radius="1">
+		<monster name="Yellow Butterfly" x="0" y="0" z="7" spawntime="60" />
+		<monster name="Yellow Butterfly" x="1" y="0" z="7" spawntime="-2013703424" />
+	</spawn>
+	<spawn centerx="32732" centery="32851" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32930" centery="32851" centerz="7" radius="3">
 		<monster name="lizard sentinel" x="3" y="-2" z="7" spawntime="60" />
@@ -18457,8 +18610,8 @@
 	<spawn centerx="33194" centery="32851" centerz="7" radius="3">
 		<npc name="Rahkem" x="2" y="0" z="7" spawntime="60" />
 	</spawn>
-	<spawn centerx="32594" centery="32852" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
+	<spawn centerx="32845" centery="32852" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32976" centery="32852" centerz="7" radius="2">
 		<monster name="lizard templar" x="0" y="-2" z="7" spawntime="60" />
@@ -18475,9 +18628,6 @@
 	</spawn>
 	<spawn centerx="32837" centery="32853" centerz="7" radius="1">
 		<monster name="spider" x="1" y="0" z="7" spawntime="60" />
-	</spawn>
-	<spawn centerx="32586" centery="32854" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32609" centery="32854" centerz="7" radius="1">
 		<monster name="Panda" x="1" y="0" z="7" spawntime="60" />
@@ -18498,9 +18648,6 @@
 		<monster name="lizard snakecharmer" x="0" y="0" z="7" spawntime="60" />
 		<monster name="lizard sentinel" x="-2" y="2" z="7" spawntime="60" />
 	</spawn>
-	<spawn centerx="32586" centery="32856" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
-	</spawn>
 	<spawn centerx="32649" centery="32856" centerz="7" radius="1">
 		<monster name="terror bird" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
@@ -18515,12 +18662,6 @@
 	</spawn>
 	<spawn centerx="32709" centery="32857" centerz="7" radius="1">
 		<monster name="snake" x="1" y="0" z="7" spawntime="60" />
-	</spawn>
-	<spawn centerx="32603" centery="32858" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
-	</spawn>
-	<spawn centerx="32605" centery="32858" centerz="7" radius="1">
-		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32978" centery="32858" centerz="7" radius="2">
 		<monster name="lizard sentinel" x="-1" y="-2" z="7" spawntime="60" />
@@ -18662,6 +18803,12 @@
 	<spawn centerx="32946" centery="32869" centerz="7" radius="2">
 		<monster name="lizard snakecharmer" x="1" y="1" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32581" centery="32870" centerz="7" radius="1">
+		<monster name="butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32584" centery="32870" centerz="7" radius="1">
+		<monster name="butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32772" centery="32870" centerz="7" radius="1">
 		<monster name="centipede" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
@@ -18670,6 +18817,9 @@
 	</spawn>
 	<spawn centerx="32785" centery="32871" centerz="7" radius="1">
 		<monster name="wasp" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32859" centery="32871" centerz="7" radius="1">
+		<monster name="Red Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32292" centery="32872" centerz="7" radius="3">
 		<monster name="rat" x="-2" y="-3" z="7" spawntime="60" />
@@ -18701,6 +18851,9 @@
 	<spawn centerx="32808" centery="32874" centerz="7" radius="1">
 		<monster name="tarantula" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32849" centery="32874" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32930" centery="32874" centerz="7" radius="3">
 		<monster name="lizard templar" x="0" y="-1" z="7" spawntime="60" />
 		<monster name="lizard templar" x="-1" y="1" z="7" spawntime="60" />
@@ -18709,6 +18862,9 @@
 		<monster name="Tortoise" x="2" y="-4" z="7" spawntime="60" />
 		<monster name="crimson frog" x="2" y="-2" z="7" spawntime="60" />
 		<monster name="Tortoise" x="0" y="3" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32816" centery="32876" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32904" centery="32876" centerz="7" radius="2">
 		<monster name="lizard templar" x="2" y="-2" z="7" spawntime="60" />
@@ -18776,6 +18932,9 @@
 		<monster name="toad" x="-2" y="2" z="7" spawntime="60" />
 		<monster name="coral frog" x="4" y="5" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32623" centery="32884" centerz="7" radius="1">
+		<monster name="Blue Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32949" centery="32884" centerz="7" radius="2">
 		<monster name="lizard sentinel" x="-1" y="-1" z="7" spawntime="60" />
 		<monster name="lizard sentinel" x="0" y="1" z="7" spawntime="60" />
@@ -18835,6 +18994,9 @@
 	</spawn>
 	<spawn centerx="32817" centery="32890" centerz="7" radius="1">
 		<monster name="butterfly" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32625" centery="32891" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32821" centery="32891" centerz="7" radius="1">
 		<monster name="snake" x="1" y="0" z="7" spawntime="60" />
@@ -19179,6 +19341,9 @@
 		<monster name="crimson frog" x="4" y="4" z="7" spawntime="60" />
 		<monster name="Tortoise" x="2" y="5" z="7" spawntime="60" />
 	</spawn>
+	<spawn centerx="32778" centery="32933" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
+	</spawn>
 	<spawn centerx="32818" centery="32933" centerz="7" radius="1">
 		<monster name="poison spider" x="1" y="0" z="7" spawntime="60" />
 	</spawn>
@@ -19187,6 +19352,9 @@
 	</spawn>
 	<spawn centerx="32675" centery="32934" centerz="7" radius="1">
 		<monster name="Panda" x="1" y="0" z="7" spawntime="60" />
+	</spawn>
+	<spawn centerx="32689" centery="32934" centerz="7" radius="1">
+		<monster name="Purple Butterfly" x="0" y="0" z="7" spawntime="60" />
 	</spawn>
 	<spawn centerx="32706" centery="32934" centerz="7" radius="1">
 		<monster name="spit nettle" x="1" y="0" z="7" spawntime="60" />
@@ -53355,8 +53523,7 @@
 		<monster name="dwarf soldier" x="1" y="0" z="13" spawntime="60" />
 	</spawn>
 	<spawn centerx="32172" centery="31929" centerz="13" radius="2">
-		<monster name="ghoul" x="-2" y="-1" z="13" spawntime="60" />
-		<monster name="monk" x="1" y="2" z="13" spawntime="60" />
+		<monster name="ghoul" x="-1" y="1" z="13" spawntime="60" />
 	</spawn>
 	<spawn centerx="32457" centery="31929" centerz="13" radius="2">
 		<monster name="slime" x="-2" y="-1" z="13" spawntime="60" />


### PR DESCRIPTION
-     Sweaty Cyclopse can be reached, the wheat was doubled and the lower layer couldn't be removed with scythe
-     Explorer Society quest-log "fixed" (I forgot my Tibia password so I couldn't check what the actual text is or if it even exists, I just added so it still shows up in the quest log after completion because it seems like it should)
-     Explorer Society - Family Brooch door missing aid.
-     Explorer Society - fixed NPCs a bit and made them easier to talk to (mortimer/angus)
-     Explorer Society - Elvith now sells elven poetry book during the quest in case you lost it. 
-     Explorer Society - There were no purple butterfly-spawns (and butterfly.lua or something isn't working properly, it's corpses are always the same). Added purple butterflies.
-     Explorer Society - TheAstralPortals - Doors and tiles missing uid/aid respectively on map. Changed coordinates in carvingTPPortHope.lua so they don't point directly at eachother crashing the server
-     Explorer Society - The Undersea Kingdom - Berenice.lua was messy
-     Houses in Carlin will save their walls. Size of houses in mysql and homepage or whatever might be messed up though. Personally I prefer walls saving.
-     Added spells to learn from NPCs in Edron.(didn't playtest if they work properly and the price might be wrong since I took it from the Realera wiki)